### PR TITLE
fix: update TextField component value after Cleave changes value on internal Input element

### DIFF
--- a/src/main/java/org/vaadin/textfieldformatter/CleaveExtension.java
+++ b/src/main/java/org/vaadin/textfieldformatter/CleaveExtension.java
@@ -1,13 +1,14 @@
 package org.vaadin.textfieldformatter;
 
-import java.lang.ref.WeakReference;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
+
+import java.lang.ref.WeakReference;
 
 @Tag("jh-textfield-formatter")
 @NpmPackage(value = "cleave.js", version = "1.6.0")
@@ -38,6 +39,10 @@ public abstract class CleaveExtension extends Component {
 		component.getElement().appendChild(getElement());
 		getElement().setPropertyJson("conf", getConfiguration().toJson());
 	}
+
+	public void getRawValue(SerializableConsumer<String> onValueObtained) {
+		getElement().callJsFunction("getRawValue").then(String.class, onValueObtained);
+    }
 
 	public void remove() {
 		if (attachRegistration != null) {

--- a/src/main/resources/META-INF/resources/frontend/jh-textfield-formatter/jh-textfield-formatter.js
+++ b/src/main/resources/META-INF/resources/frontend/jh-textfield-formatter/jh-textfield-formatter.js
@@ -56,6 +56,11 @@ class JhTextfieldFormatter extends PolymerElement {
       }
     }
 
+    newConf.onValueChanged = (event) => {
+      const inputElementValue = event.target.value;
+      this.parentElement.value = inputElementValue;
+    }
+
     if (this.cleave) {
       this.cleave.destroy();
       this.cleave = undefined;

--- a/src/main/resources/META-INF/resources/frontend/jh-textfield-formatter/jh-textfield-formatter.js
+++ b/src/main/resources/META-INF/resources/frontend/jh-textfield-formatter/jh-textfield-formatter.js
@@ -44,6 +44,10 @@ class JhTextfieldFormatter extends PolymerElement {
     }
   }
 
+  getRawValue() {
+    return this.cleave.getRawValue();
+  }
+
   _confChanged(newConf, oldConf) {
     if (!newConf) {
       return;

--- a/src/test/java/org/vaadin/textfieldformatter/NumeralFieldFormatterUI.java
+++ b/src/test/java/org/vaadin/textfieldformatter/NumeralFieldFormatterUI.java
@@ -14,15 +14,19 @@ import org.vaadin.textfieldformatter.NumeralFieldFormatterUI.ThousandsGroupLakh;
 import org.vaadin.textfieldformatter.NumeralFieldFormatterUI.ThousandsGroupNone;
 import org.vaadin.textfieldformatter.NumeralFieldFormatterUI.ThousandsGroupThousand;
 import org.vaadin.textfieldformatter.NumeralFieldFormatterUI.ThousandsGroupWan;
+import org.vaadin.textfieldformatter.NumeralFieldFormatterUI.BinderRequiredValidation;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.value.ValueChangeMode;
 
 @RouteParams({ DefaultValues.class, CustomValue.class, ThousandsGroupThousand.class, ThousandsGroupLakh.class,
 		ThousandsGroupWan.class, ThousandsGroupNone.class, IntegerScale.class, DecimalScale.class, DecimalMark.class,
-		PositiveOnly.class, SignBeforePrefix.class, Postfix.class, DontStripLeadingZeroes.class })
+		PositiveOnly.class, SignBeforePrefix.class, Postfix.class, DontStripLeadingZeroes.class,
+		BinderRequiredValidation.class})
 public class NumeralFieldFormatterUI extends AbstractTest {
 
 	@Override
@@ -173,5 +177,34 @@ public class NumeralFieldFormatterUI extends AbstractTest {
 			return tf;
 		}
 
+	}
+
+	public static class BinderRequiredValidation extends UITestConfiguration {
+
+		private String value;
+
+		@Override
+		public Component getTestComponent() {
+			TextField tf = new TextField();
+			tf.setValueChangeMode(ValueChangeMode.EAGER);
+			tf.addValueChangeListener(l -> Notification.show("Value: " + l.getValue()));
+
+			new NumeralFieldFormatter().extend(tf);
+
+			Binder<BinderRequiredValidation> binder = new Binder<>();
+			binder.forField(tf)
+					.asRequired("This value is required")
+					.bind(BinderRequiredValidation::getValue, BinderRequiredValidation::setValue);
+
+			return tf;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
 	}
 }

--- a/src/test/java/org/vaadin/textfieldformatter/NumeralFieldFormatterUI.java
+++ b/src/test/java/org/vaadin/textfieldformatter/NumeralFieldFormatterUI.java
@@ -189,7 +189,12 @@ public class NumeralFieldFormatterUI extends AbstractTest {
 			tf.setValueChangeMode(ValueChangeMode.EAGER);
 			tf.addValueChangeListener(l -> Notification.show("Value: " + l.getValue()));
 
-			new NumeralFieldFormatter().extend(tf);
+			final NumeralFieldFormatter numeralFieldFormatter = new NumeralFieldFormatter();
+			numeralFieldFormatter.extend(tf);
+
+			tf.addValueChangeListener(l ->
+					numeralFieldFormatter.getRawValue(rawValue -> Notification.show("Raw value: " + rawValue))
+			);
 
 			Binder<BinderRequiredValidation> binder = new Binder<>();
 			binder.forField(tf)


### PR DESCRIPTION
Hi, I'm Bretislav from the Vaadin team. Vaadin is interested in fixing [this issue](https://github.com/johanneshayry/textfieldformatter/issues/66) and therefore we looked into it.

It seems that there is truly a regression from https://github.com/johanneshayry/textfieldformatter/commit/073f3eb7b8d13370c008c5ba112cbc3cc17891fb which attached Cleave.js to the underlying `<input>` instead of the `vaadin-text-field` element. 

The issue here is then _the order_ of `input` event processing. There are two `input` event handlers attached to the underlying `<input>` element:
1. the first one comes from the Vaadin and watches for value changes - if the value is changed in the `<input>`, the value is copied to the `value` property of the `vaadin-text-field`. It is then this value of `vaadin-text-field` which is sent to the server as a new value. 
2. Second `input` event handler is the Cleave one -> it checks the new value and modifies it according to the chosen format. It then sets the new value to the underlying `<input>` element. But new value is not automatically copied also to the `vaadin-text-field` value.

So Cleave does its job, but the new value is not copied to the `vaadin-text-field` component. Incorrect value is then sent to the server, which is causing validation issues and client-server value synchronization issues.

The fix is to update the `vaadin-text-field` value after Cleave finished processing. I've added `onValueChanged` handler to Cleave which seems to be a good place where to do this.

I've tested with existing tests and all seems to be ok. I've also tested if binder validation works (including testing with various Value Change Modes) and all seems to be fine.

This PR fixed these two issues:

Fixes https://github.com/johanneshayry/textfieldformatter/issues/66
Fixes https://github.com/johanneshayry/textfieldformatter/issues/56