### PR TITLE
Fix serialization of Vaadin components

### DIFF
--- a/src/main/java/org/vaadin/textfieldformatter/CleaveConfiguration.java
+++ b/src/main/java/org/vaadin/textfieldformatter/CleaveConfiguration.java
@@ -1,12 +1,13 @@
 package org.vaadin.textfieldformatter;
 
+import java.io.Serializable;
 import java.util.function.Consumer;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
-public class CleaveConfiguration {
+public class CleaveConfiguration implements Serializable {
 	public Boolean creditCard;
 	public Boolean creditCardStrictMode;
 	public String delimiter;


### PR DESCRIPTION
This change fixes serialization, as all Vaadin components should be serializable, but this add-on currently breaks it.